### PR TITLE
Add support for `XDG_STATE_HOME`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,7 @@ console.log(xdgConfig);
 export const xdgConfig: string | undefined;
 
 /**
-Directory for user-specific configuration files.
+Directory for user-specific state files.
 
 @example
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,6 +25,19 @@ console.log(xdgConfig);
 export const xdgConfig: string | undefined;
 
 /**
+Directory for user-specific configuration files.
+
+@example
+```
+import {xdgState} from 'xdg-basedir';
+
+console.log(xdgState);
+//=> '/home/sindresorhus/.local/state'
+```
+*/
+export const xdgState: string | undefined;
+
+/**
 Directory for user-specific non-essential data files.
 
 @example

--- a/index.js
+++ b/index.js
@@ -10,6 +10,9 @@ export const xdgData = env.XDG_DATA_HOME ||
 export const xdgConfig = env.XDG_CONFIG_HOME ||
 	(homeDirectory ? path.join(homeDirectory, '.config') : undefined);
 
+export const xdgState = env.XDG_STATE_HOME ||
+	(homeDirectory ? path.join(homeDirectory, '.local', 'state') : undefined);
+
 export const xdgCache = env.XDG_CACHE_HOME || (homeDirectory ? path.join(homeDirectory, '.cache') : undefined);
 
 export const xdgRuntime = env.XDG_RUNTIME_DIR || undefined;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,10 +1,12 @@
 import {expectType, expectError} from 'tsd';
-import {xdgData, xdgConfig, xdgCache, xdgRuntime, xdgConfigDirectories, xdgDataDirectories} from './index.js';
+import {xdgData, xdgConfig, xdgState, xdgCache, xdgRuntime, xdgConfigDirectories, xdgDataDirectories} from './index.js';
 
 expectType<string | undefined>(xdgData);
 expectError<string>(xdgData);
 expectType<string | undefined>(xdgConfig);
 expectError<string>(xdgConfig);
+expectType<string | undefined>(xdgState);
+expectError<string>(xdgState);
 expectType<string | undefined>(xdgCache);
 expectError<string>(xdgCache);
 expectType<string | undefined>(xdgRuntime);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -3,8 +3,8 @@ import {xdgData, xdgConfig, xdgCache, xdgRuntime, xdgConfigDirectories, xdgDataD
 
 expectType<string | undefined>(xdgData);
 expectError<string>(xdgData);
-expectType<string | undefined>(xdgCache);
-expectError<string>(xdgCache);
+expectType<string | undefined>(xdgConfig);
+expectError<string>(xdgConfig);
 expectType<string | undefined>(xdgCache);
 expectError<string>(xdgCache);
 expectType<string | undefined>(xdgRuntime);

--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,10 @@ Directory for user-specific data files.
 
 Directory for user-specific configuration files.
 
+### xdgState
+
+Directory for user-specific state files.
+
 ### xdgCache
 
 Directory for user-specific non-essential data files.

--- a/test.js
+++ b/test.js
@@ -19,6 +19,12 @@ test('x', t => {
 // 	t.is(xdgConfig, 'config');
 // });
 //
+// test('xdgState', t => {
+// 	process.env.XDG_CONFIG_HOME = 'state';
+// 	const {xdgState} = importFresh('.');
+// 	t.is(xdgState, 'state');
+// });
+//
 // test('xdgCache', t => {
 // 	process.env.XDG_CACHE_HOME = 'cache';
 // 	const {xdgCache} = importFresh('.');


### PR DESCRIPTION
Hello!

The [spec](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) recently added an `$XDG_STATE_HOME` variable. This adds support for that